### PR TITLE
Metadata access rule

### DIFF
--- a/backends/client.go
+++ b/backends/client.go
@@ -25,6 +25,11 @@ type StoreClient interface {
 	PutMapping(nodePath string, mapping interface{}, replace bool) error
 	DeleteMapping(nodePath string, dir bool) error
 	SyncMapping(mapping store.Store, stopChan chan bool)
+
+	GetAccessRule() (map[string][]store.AccessRule, error)
+	PutAccessRule(rules map[string][]store.AccessRule) error
+	DeleteAccessRule(hosts []string) error
+	SyncAccessRule(accessStore store.AccessStore, stopChan chan bool)
 }
 
 // New is used to create a storage client based on our configuration.

--- a/backends/etcdv3/client.go
+++ b/backends/etcdv3/client.go
@@ -167,6 +167,9 @@ func (c *Client) PutAccessRule(rules map[string][]store.AccessRule) error {
 
 func (c *Client) DeleteAccessRule(hosts []string) error {
 	for _, host := range hosts {
+		if host == "" {
+			continue
+		}
 		err := c.internalDelete(c.rulePrefix, path.Join("/", host), false)
 		if err != nil {
 			return err

--- a/backends/etcdv3/client_test.go
+++ b/backends/etcdv3/client_test.go
@@ -32,7 +32,7 @@ func TestClientSyncStop(t *testing.T) {
 	metastore := store.New()
 	// expect internalSync not block after stopChan has signal
 	startedChan := make(chan bool)
-	storeClient.internalSync(prefix, metastore, stopChan, startedChan)
+	storeClient.internalSync(prefix, stopChan, startedChan, storeClient.newInitStoreFunc(prefix, metastore), newProcessSyncChangeFunc(metastore))
 	initialized := <-startedChan
 	log.Info(fmt.Sprint("sync status:", initialized))
 

--- a/backends/etcdv3/client_test.go
+++ b/backends/etcdv3/client_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/yunify/metad/log"
 	"github.com/yunify/metad/store"
 	"math/rand"
+	"sync"
 	"testing"
 	"time"
 )
@@ -31,9 +32,47 @@ func TestClientSyncStop(t *testing.T) {
 
 	metastore := store.New()
 	// expect internalSync not block after stopChan has signal
-	startedChan := make(chan bool)
-	storeClient.internalSync(prefix, stopChan, startedChan, storeClient.newInitStoreFunc(prefix, metastore), newProcessSyncChangeFunc(metastore))
-	initialized := <-startedChan
-	log.Info(fmt.Sprint("sync status:", initialized))
+	initWG := &sync.WaitGroup{}
+	initWG.Add(1)
 
+	doneWG := &sync.WaitGroup{}
+	doneWG.Add(1)
+
+	go func() {
+		storeClient.internalSync(prefix, stopChan, initWG, storeClient.newInitStoreFunc(prefix, metastore), newProcessSyncChangeFunc(metastore))
+		doneWG.Done()
+	}()
+	initWG.Wait()
+	doneWG.Wait()
+}
+
+func TestClientSyncStopWhenInitError(t *testing.T) {
+
+	prefix := fmt.Sprintf("/prefix%v", rand.Intn(1000))
+
+	stopChan := make(chan bool)
+	log.Info("prefix is %s", prefix)
+	nodes := []string{"http://127.0.0.1:2379"}
+	storeClient, err := NewEtcdClient("default", prefix, nodes, "", "", "", false, "", "")
+	assert.NoError(t, err)
+	go func() {
+		time.Sleep(3 * time.Second)
+		stopChan <- true
+	}()
+
+	metastore := store.New()
+	// expect internalSync not block after stopChan has signal
+	initWG := &sync.WaitGroup{}
+	initWG.Add(1)
+
+	doneWG := &sync.WaitGroup{}
+	doneWG.Add(1)
+	go func() {
+		storeClient.internalSync(prefix, stopChan, initWG, func() error {
+			return fmt.Errorf("always error")
+		}, newProcessSyncChangeFunc(metastore))
+		doneWG.Done()
+	}()
+	initWG.Wait()
+	doneWG.Wait()
 }

--- a/config.go
+++ b/config.go
@@ -31,7 +31,6 @@ var (
 	pprof        bool
 	logLevel     string
 	enableXff    bool
-	onlySelf     bool
 	prefix       string
 	listen       string
 	listenManage string
@@ -55,7 +54,6 @@ type Config struct {
 	PIDFile      string   `yaml:"pid_file"`
 	EnableXff    bool     `yaml:"xff"`
 	Prefix       string   `yaml:"prefix"`
-	OnlySelf     bool     `yaml:"only_self"`
 	Listen       string   `yaml:"listen"`
 	ListenManage string   `yaml:"listen_manage"`
 	BasicAuth    bool     `yaml:"basic_auth"`
@@ -77,7 +75,6 @@ func init() {
 	flag.StringVar(&pidFile, "pid_file", "", "PID to write to")
 	flag.BoolVar(&enableXff, "xff", false, "X-Forwarded-For header support")
 	flag.StringVar(&prefix, "prefix", "", "Backend key path prefix")
-	flag.BoolVar(&onlySelf, "only_self", false, "Only support self metadata query")
 	flag.StringVar(&group, "group", "default", "The metad's group name, same group share same mapping config from backend")
 	flag.StringVar(&listen, "listen", ":80", "Address to listen to (TCP)")
 	flag.StringVar(&listenManage, "listen_manage", "127.0.0.1:9611", "Address to listen to for manage requests (TCP)")
@@ -165,8 +162,6 @@ func setConfigFromFlag(config *Config, f *flag.Flag) {
 		config.EnableXff = enableXff
 	case "prefix":
 		config.Prefix = prefix
-	case "only_self":
-		config.OnlySelf = onlySelf
 	case "group":
 		config.Group = group
 	case "listen":

--- a/config_test.go
+++ b/config_test.go
@@ -15,7 +15,6 @@ func TestConfigFile(t *testing.T) {
 		PIDFile:      "/var/run/metad.pid",
 		EnableXff:    true,
 		Prefix:       "/users/uid1",
-		OnlySelf:     true,
 		Group:        "default",
 		Listen:       ":8080",
 		ListenManage: "127.0.0.1:9611",

--- a/metad.go
+++ b/metad.go
@@ -140,6 +140,10 @@ func (m *Metad) initManageRouter() {
 	data.HandleFunc("/{nodePath:.*}", m.manageWrapper(m.dataUpdate)).Methods("POST", "PUT")
 	data.HandleFunc("/{nodePath:.*}", m.manageWrapper(m.dataDelete)).Methods("DELETE")
 
+	v1.HandleFunc("/rule", m.manageWrapper(m.accessRuleGet)).Methods("GET")
+	v1.HandleFunc("/rule", m.manageWrapper(m.accessRuleUpdate)).Methods("POST", "PUT")
+	v1.HandleFunc("/rule", m.manageWrapper(m.accessRuleDelete)).Methods("DELETE")
+
 	rule := v1.PathPrefix("/rule").Subrouter()
 	rule.HandleFunc("/", m.manageWrapper(m.accessRuleGet)).Methods("GET")
 	rule.HandleFunc("/", m.manageWrapper(m.accessRuleUpdate)).Methods("POST", "PUT")
@@ -306,7 +310,10 @@ func (m *Metad) mappingDelete(ctx context.Context, req *http.Request) (interface
 }
 
 func (m *Metad) accessRuleGet(ctx context.Context, req *http.Request) (interface{}, *HttpError) {
-	return nil, nil
+	hostsStr := req.FormValue("hosts")
+	hosts := strings.Split(hostsStr, ",")
+	val := m.metadataRepo.GetAccessRule(hosts)
+	return val, nil
 }
 
 func (m *Metad) accessRuleUpdate(ctx context.Context, req *http.Request) (interface{}, *HttpError) {
@@ -329,7 +336,10 @@ func (m *Metad) accessRuleUpdate(ctx context.Context, req *http.Request) (interf
 }
 
 func (m *Metad) accessRuleDelete(ctx context.Context, req *http.Request) (interface{}, *HttpError) {
-	return nil, nil
+	hostsStr := req.FormValue("hosts")
+	hosts := strings.Split(hostsStr, ",")
+	err := m.metadataRepo.DeleteAccessRule(hosts)
+	return nil, NewServerError(err)
 }
 
 func contentType(req *http.Request) int {

--- a/metad.go
+++ b/metad.go
@@ -311,7 +311,10 @@ func (m *Metad) mappingDelete(ctx context.Context, req *http.Request) (interface
 
 func (m *Metad) accessRuleGet(ctx context.Context, req *http.Request) (interface{}, *HttpError) {
 	hostsStr := req.FormValue("hosts")
-	hosts := strings.Split(hostsStr, ",")
+	var hosts []string
+	if hostsStr != "" {
+		hosts = strings.Split(hostsStr, ",")
+	}
 	val := m.metadataRepo.GetAccessRule(hosts)
 	return val, nil
 }
@@ -337,7 +340,10 @@ func (m *Metad) accessRuleUpdate(ctx context.Context, req *http.Request) (interf
 
 func (m *Metad) accessRuleDelete(ctx context.Context, req *http.Request) (interface{}, *HttpError) {
 	hostsStr := req.FormValue("hosts")
-	hosts := strings.Split(hostsStr, ",")
+	var hosts []string
+	if hostsStr != "" {
+		hosts = strings.Split(hostsStr, ",")
+	}
 	err := m.metadataRepo.DeleteAccessRule(hosts)
 	return nil, NewServerError(err)
 }

--- a/metad_test.go
+++ b/metad_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/yunify/metad/log"
 	"github.com/yunify/metad/util"
+	"math/rand"
 )
 
 var (
@@ -21,16 +22,11 @@ var (
 
 func init() {
 	log.SetLevel("debug")
+	rand.Seed(time.Now().UnixNano())
 }
 
 func TestMetad(t *testing.T) {
-	config := &Config{
-		Backend: testBackend,
-	}
-	metad, err := New(config)
-	assert.NoError(t, err)
-
-	metad.Init()
+	metad := NewTestMetad()
 
 	defer metad.Stop()
 
@@ -202,13 +198,7 @@ func TestMetad(t *testing.T) {
 }
 
 func TestMetadWatch(t *testing.T) {
-	config := &Config{
-		Backend: testBackend,
-	}
-	metad, err := New(config)
-	assert.NoError(t, err)
-
-	metad.Init()
+	metad := NewTestMetad()
 
 	defer metad.Stop()
 	ip := "192.168.1.1"
@@ -283,13 +273,7 @@ func TestMetadWatch(t *testing.T) {
 }
 
 func TestMetadWatchSelf(t *testing.T) {
-	config := &Config{
-		Backend: testBackend,
-	}
-	metad, err := New(config)
-	assert.NoError(t, err)
-
-	metad.Init()
+	metad := NewTestMetad()
 
 	defer metad.Stop()
 
@@ -371,13 +355,7 @@ func TestMetadWatchSelf(t *testing.T) {
 }
 
 func TestMetadMappingDelete(t *testing.T) {
-	config := &Config{
-		Backend: testBackend,
-	}
-	metad, err := New(config)
-	assert.NoError(t, err)
-
-	metad.Init()
+	metad := NewTestMetad()
 
 	defer metad.Stop()
 
@@ -437,14 +415,7 @@ func TestMetadMappingDelete(t *testing.T) {
 }
 
 func TestMetadAccessRule(t *testing.T) {
-	config := &Config{
-		Backend: testBackend,
-	}
-	metad, err := New(config)
-	assert.NoError(t, err)
-
-	metad.Init()
-
+	metad := NewTestMetad()
 	defer metad.Stop()
 
 	data := map[string]interface{}{
@@ -517,6 +488,21 @@ func TestMetadAccessRule(t *testing.T) {
 	assert.Equal(t, "1234567", util.GetMapValue(parse(w), "/self/cluster/env/secret"))
 	// node2 can not access cl-1
 	assert.Equal(t, "", util.GetMapValue(parse(w), "/clusters/cl-1/name"))
+}
+
+func NewTestMetad() *Metad {
+	group := fmt.Sprintf("/group%v", rand.Intn(10000))
+	config := &Config{
+		Backend: testBackend,
+		Group:   group,
+	}
+	metad, err := New(config)
+	if err != nil {
+		panic(err)
+	}
+
+	metad.Init()
+	return metad
 }
 
 func getAndCheckMapping(metad *Metad, t *testing.T, ip string, exist bool) {

--- a/metad_test.go
+++ b/metad_test.go
@@ -465,6 +465,14 @@ func TestMetadAccessRule(t *testing.T) {
 
 	time.Sleep(sleepTime)
 
+	req = httptest.NewRequest("GET", "/v1/rule", nil)
+	req.Header.Set("accept", "application/json")
+	w = httptest.NewRecorder()
+	metad.manageRouter.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+	assert.Equal(t, "/", util.GetMapValue(parse(w), "/192.168.1.1/0/path"))
+	assert.Equal(t, "1", util.GetMapValue(parse(w), "/192.168.1.1/2/mode"))
+
 	req = httptest.NewRequest("GET", "/", nil)
 	req.RemoteAddr = "192.168.1.1:1234"
 	req.Header.Set("accept", "application/json")
@@ -541,7 +549,7 @@ func parse(w *httptest.ResponseRecorder) interface{} {
 	log.Debug("%s response %s", requestID, w.Body.String())
 	err := json.Unmarshal(w.Body.Bytes(), &result)
 	if err != nil {
-		log.Error("json_err: %s", err.Error())
+		panic(fmt.Errorf("json_err: %s", err.Error()))
 	}
 	return result
 }

--- a/metadata/metarepo.go
+++ b/metadata/metarepo.go
@@ -19,30 +19,26 @@ import (
 const DEFAULT_WATCH_BUF_LEN = 100
 
 type MetadataRepo struct {
-	onlySelf        bool
 	mapping         store.Store
 	storeClient     backends.StoreClient
 	data            store.Store
+	accessTrees     map[string]*store.AccessTree
 	metaStopChan    chan bool
 	mappingStopChan chan bool
 	timerPool       *util.TimerPool
 }
 
-func New(onlySelf bool, storeClient backends.StoreClient) *MetadataRepo {
+func New(storeClient backends.StoreClient) *MetadataRepo {
 	metadataRepo := MetadataRepo{
-		onlySelf:        onlySelf,
 		mapping:         store.New(),
 		storeClient:     storeClient,
 		data:            store.New(),
+		accessTrees:     make(map[string]*store.AccessTree),
 		metaStopChan:    make(chan bool),
 		mappingStopChan: make(chan bool),
 		timerPool:       util.NewTimerPool(100 * time.Millisecond),
 	}
 	return &metadataRepo
-}
-
-func (r *MetadataRepo) SetOnlySelf(onlySelf bool) {
-	r.onlySelf = onlySelf
 }
 
 func (r *MetadataRepo) StartSync() {
@@ -69,27 +65,54 @@ func (r *MetadataRepo) StopSync() {
 	r.mapping.Destroy()
 }
 
-func (r *MetadataRepo) Root(clientIP string, nodePath string) (currentVersion int64, val interface{}) {
-	nodePath = path.Join("/", nodePath)
-	if r.onlySelf {
-		currentVersion = r.data.Version()
-		if nodePath == "/" {
-			mapVal := make(map[string]interface{})
-			selfVal := r.Self(clientIP, "/")
-			if selfVal != nil {
-				mapVal["self"] = selfVal
+func (r *MetadataRepo) getAccessTree(clientIP string) *store.AccessTree {
+	accessTree := r.accessTrees[clientIP]
+	//for compatible with old version, auto convert mapping to AccessRule
+	if accessTree == nil {
+		mappingData := r.GetMapping(path.Join("/", clientIP))
+		if mappingData == nil {
+			if log.IsDebugEnable() {
+				log.Debug("Can not find mapping for %s", clientIP)
 			}
-			val = mapVal
+			return nil
 		}
-	} else {
-		currentVersion, val = r.data.Get(nodePath)
-		if val != nil && nodePath == "/" {
-			selfVal := r.Self(clientIP, "/")
-			if selfVal != nil {
-				mapVal, ok := val.(map[string]interface{})
-				if ok {
-					mapVal["self"] = selfVal
-				}
+		mapping, mok := mappingData.(map[string]interface{})
+		if !mok {
+			log.Warning("Mapping for %s is not a map, result:%v", clientIP, mappingData)
+			return nil
+		}
+		flattenMapping := flatmap.Flatten(mapping)
+		rules := []store.AccessRule{}
+		for _, dataPath := range flattenMapping {
+			rules = append(rules, store.AccessRule{Path: dataPath, Mode: store.AccessModeRead})
+		}
+		accessTree = store.NewAccessTree(rules)
+	}
+	return accessTree
+}
+
+func (r *MetadataRepo) Root(clientIP string, nodePath string) (currentVersion int64, val interface{}) {
+	if clientIP == "" {
+		panic(errors.New("clientIP must not be empty."))
+	}
+	nodePath = path.Join("/", nodePath)
+	accessTree := r.getAccessTree(clientIP)
+	if accessTree == nil {
+		return
+	}
+	traveller := r.data.Traveller(accessTree)
+	defer traveller.Close()
+	if !traveller.Enter(nodePath) {
+		return
+	}
+	currentVersion = traveller.GetVersion()
+	val = traveller.GetValue()
+	if val != nil && nodePath == "/" {
+		selfVal := r.self(clientIP, "/", traveller)
+		if selfVal != nil {
+			mapVal, ok := val.(map[string]interface{})
+			if ok {
+				mapVal["self"] = selfVal
 			}
 		}
 	}
@@ -98,17 +121,8 @@ func (r *MetadataRepo) Root(clientIP string, nodePath string) (currentVersion in
 
 func (r *MetadataRepo) Watch(ctx context.Context, clientIP string, nodePath string) interface{} {
 	nodePath = path.Join("/", nodePath)
-
-	if r.onlySelf {
-		if nodePath == "/" {
-			return r.WatchSelf(ctx, clientIP, "/")
-		} else {
-			return nil
-		}
-	} else {
-		w := r.data.Watch(nodePath, DEFAULT_WATCH_BUF_LEN)
-		return r.changeToResult(w, ctx.Done())
-	}
+	w := r.data.Watch(nodePath, DEFAULT_WATCH_BUF_LEN)
+	return r.changeToResult(w, ctx.Done())
 }
 
 var TIMER_NIL *time.Timer = &time.Timer{C: nil}
@@ -203,6 +217,17 @@ func (r *MetadataRepo) Self(clientIP string, nodePath string) interface{} {
 		panic(errors.New("clientIP must not be empty."))
 	}
 	nodePath = path.Join("/", nodePath)
+
+	accessTree := r.getAccessTree(clientIP)
+	if accessTree == nil {
+		return nil
+	}
+	traveller := r.data.Traveller(accessTree)
+	defer traveller.Close()
+	return r.self(clientIP, nodePath, traveller)
+}
+
+func (r *MetadataRepo) self(clientIP string, nodePath string, traveller store.Traveller) interface{} {
 	mappingData := r.GetMapping(path.Join("/", clientIP))
 	if mappingData == nil {
 		if log.IsDebugEnable() {
@@ -215,16 +240,20 @@ func (r *MetadataRepo) Self(clientIP string, nodePath string) interface{} {
 		log.Warning("Mapping for %s is not a map, result:%v", clientIP, mappingData)
 		return nil
 	}
-	return r.getMappingDatas(nodePath, mapping)
+	return r.getMappingDatas(nodePath, mapping, traveller)
 }
 
-func (r *MetadataRepo) getMappingData(nodePath, link string) interface{} {
+func (r *MetadataRepo) getMappingData(nodePath, link string, traveller store.Traveller) interface{} {
 	nodePath = path.Join(link, nodePath)
-	_, val := r.data.Get(nodePath)
-	return val
+	if traveller.Enter(nodePath) {
+		val := traveller.GetValue()
+		traveller.BackToRoot()
+		return val
+	}
+	return nil
 }
 
-func (r *MetadataRepo) getMappingDatas(nodePath string, mapping map[string]interface{}) interface{} {
+func (r *MetadataRepo) getMappingDatas(nodePath string, mapping map[string]interface{}, traveller store.Traveller) interface{} {
 	nodePath = path.Join("/", nodePath)
 	paths := strings.Split(nodePath, "/")[1:] // trim first blank item
 	// nodePath is "/"
@@ -233,7 +262,7 @@ func (r *MetadataRepo) getMappingDatas(nodePath string, mapping map[string]inter
 		for k, v := range mapping {
 			submapping, isMap := v.(map[string]interface{})
 			if isMap {
-				val := r.getMappingDatas("/", submapping)
+				val := r.getMappingDatas("/", submapping, traveller)
 				if val != nil {
 					meta[k] = val
 				} else {
@@ -241,7 +270,7 @@ func (r *MetadataRepo) getMappingDatas(nodePath string, mapping map[string]inter
 				}
 			} else {
 				subNodePath := fmt.Sprintf("%v", v)
-				val := r.getMappingData("/", subNodePath)
+				val := r.getMappingData("/", subNodePath, traveller)
 				if val != nil {
 					meta[k] = val
 				} else {
@@ -257,9 +286,9 @@ func (r *MetadataRepo) getMappingDatas(nodePath string, mapping map[string]inter
 		if ok {
 			submapping, isMap := elemValue.(map[string]interface{})
 			if isMap {
-				return r.getMappingDatas(path.Join(paths[1:]...), submapping)
+				return r.getMappingDatas(path.Join(paths[1:]...), submapping, traveller)
 			} else {
-				return r.getMappingData(path.Join(paths[1:]...), fmt.Sprintf("%v", elemValue))
+				return r.getMappingData(path.Join(paths[1:]...), fmt.Sprintf("%v", elemValue), traveller)
 			}
 		} else {
 			if log.IsDebugEnable() {
@@ -398,6 +427,21 @@ func (r *MetadataRepo) DeleteMapping(nodePath string, subs ...string) error {
 
 func (r *MetadataRepo) DataVersion() int64 {
 	return r.data.Version()
+}
+
+func (r *MetadataRepo) PutAccessRule(rulesMap map[string][]store.AccessRule) error {
+	for host, rules := range rulesMap {
+		r.accessTrees[host] = store.NewAccessTree(rules)
+	}
+	return nil
+}
+
+func (r *MetadataRepo) DeleteAccessRule(host string) {
+	delete(r.accessTrees, host)
+}
+
+func (r *MetadataRepo) GetAccessRule(host string) map[string][]store.AccessRule {
+	return nil
 }
 
 func checkSubs(subs []string) error {

--- a/metadata/metarepo.go
+++ b/metadata/metarepo.go
@@ -448,6 +448,9 @@ func (r *MetadataRepo) PutAccessRule(rulesMap map[string][]store.AccessRule) err
 }
 
 func (r *MetadataRepo) DeleteAccessRule(hosts []string) error {
+	if len(hosts) == 0 {
+		return nil
+	}
 	return r.storeClient.DeleteAccessRule(hosts)
 }
 

--- a/metadata/metarepo_test.go
+++ b/metadata/metarepo_test.go
@@ -41,11 +41,6 @@ func TestMetarepoData(t *testing.T) {
 	metarepo := New(storeClient)
 	metarepo.DeleteData("/")
 
-	metarepo.StartSync()
-
-	testData := FillTestData(metarepo)
-	time.Sleep(sleepTime)
-	ValidTestData(t, testData, metarepo.data)
 	clientIP := "192.168.0.1"
 	accessRule := map[string][]store.AccessRule{
 		clientIP: {
@@ -53,6 +48,13 @@ func TestMetarepoData(t *testing.T) {
 		},
 	}
 	metarepo.PutAccessRule(accessRule)
+
+	metarepo.StartSync()
+
+	testData := FillTestData(metarepo)
+	time.Sleep(sleepTime)
+	ValidTestData(t, testData, metarepo.data)
+
 	_, val := metarepo.Root(clientIP, "/nodes/0")
 	assert.NotNil(t, val)
 

--- a/metadata/metarepo_test.go
+++ b/metadata/metarepo_test.go
@@ -26,19 +26,7 @@ var (
 
 func TestMetarepoData(t *testing.T) {
 
-	prefix := fmt.Sprintf("/prefix%v", rand.Intn(1000))
-
-	nodes := backends.GetDefaultBackends(backend)
-
-	config := backends.Config{
-		Backend:      backend,
-		BackendNodes: nodes,
-		Prefix:       prefix,
-	}
-	storeClient, err := backends.New(config)
-	assert.NoError(t, err)
-
-	metarepo := New(storeClient)
+	metarepo := NewTestMetarepo()
 	metarepo.DeleteData("/")
 
 	clientIP := "192.168.0.1"
@@ -72,7 +60,7 @@ func TestMetarepoData(t *testing.T) {
 
 	subs := []string{"1", "3", "noexistkey"}
 	//test batch delete
-	err = metarepo.DeleteData("nodes", subs...)
+	err := metarepo.DeleteData("nodes", subs...)
 	time.Sleep(sleepTime)
 	assert.NoError(t, err)
 
@@ -90,20 +78,7 @@ func TestMetarepoData(t *testing.T) {
 
 func TestMetarepoMapping(t *testing.T) {
 
-	prefix := fmt.Sprintf("/prefix%v", rand.Intn(1000))
-	group := fmt.Sprintf("/group%v", rand.Intn(1000))
-	nodes := backends.GetDefaultBackends(backend)
-
-	config := backends.Config{
-		Backend:      backend,
-		BackendNodes: nodes,
-		Prefix:       prefix,
-		Group:        group,
-	}
-	storeClient, err := backends.New(config)
-	assert.NoError(t, err)
-
-	metarepo := New(storeClient)
+	metarepo := NewTestMetarepo()
 	metarepo.DeleteData("/")
 	metarepo.DeleteMapping("/")
 
@@ -120,7 +95,7 @@ func TestMetarepoMapping(t *testing.T) {
 		mappings[ip] = mapping
 	}
 	// batch update
-	err = metarepo.PutMapping("/", mappings, true)
+	err := metarepo.PutMapping("/", mappings, true)
 	assert.NoError(t, err)
 	time.Sleep(sleepTime)
 
@@ -198,20 +173,7 @@ func TestMetarepoMapping(t *testing.T) {
 }
 
 func TestMetarepoSelf(t *testing.T) {
-	prefix := fmt.Sprintf("/prefix%v", rand.Intn(1000))
-	group := fmt.Sprintf("/group%v", rand.Intn(1000))
-	nodes := backends.GetDefaultBackends(backend)
-
-	config := backends.Config{
-		Backend:      backend,
-		BackendNodes: nodes,
-		Prefix:       prefix,
-		Group:        group,
-	}
-	storeClient, err := backends.New(config)
-	assert.NoError(t, err)
-
-	metarepo := New(storeClient)
+	metarepo := NewTestMetarepo()
 
 	metarepo.DeleteMapping("/")
 	metarepo.DeleteData("/")
@@ -233,7 +195,7 @@ func TestMetarepoSelf(t *testing.T) {
 		mappings[ip] = mapping
 	}
 	// batch update
-	err = metarepo.PutMapping("/", mappings, true)
+	err := metarepo.PutMapping("/", mappings, true)
 	assert.NoError(t, err)
 	time.Sleep(sleepTime)
 
@@ -289,20 +251,7 @@ func TestMetarepoSelf(t *testing.T) {
 
 func TestMetarepoRoot(t *testing.T) {
 
-	prefix := fmt.Sprintf("/prefix%v", rand.Intn(1000))
-	group := fmt.Sprintf("/group%v", rand.Intn(1000))
-	nodes := backends.GetDefaultBackends(backend)
-
-	config := backends.Config{
-		Backend:      backend,
-		BackendNodes: nodes,
-		Prefix:       prefix,
-		Group:        group,
-	}
-	storeClient, err := backends.New(config)
-	assert.NoError(t, err)
-
-	metarepo := New(storeClient)
+	metarepo := NewTestMetarepo()
 
 	metarepo.DeleteMapping("/")
 	metarepo.DeleteData("/")
@@ -323,7 +272,7 @@ func TestMetarepoRoot(t *testing.T) {
 
 	mapping := make(map[string]interface{})
 	mapping["node"] = "/nodes/0"
-	err = metarepo.PutMapping(ip, mapping, true)
+	err := metarepo.PutMapping(ip, mapping, true)
 	assert.NoError(t, err)
 
 	time.Sleep(sleepTime)
@@ -342,20 +291,7 @@ func TestMetarepoRoot(t *testing.T) {
 }
 
 func TestWatch(t *testing.T) {
-	prefix := fmt.Sprintf("/prefix%v", rand.Intn(1000))
-	group := fmt.Sprintf("/group%v", rand.Intn(1000))
-	nodes := backends.GetDefaultBackends(backend)
-
-	config := backends.Config{
-		Backend:      backend,
-		BackendNodes: nodes,
-		Prefix:       prefix,
-		Group:        group,
-	}
-	storeClient, err := backends.New(config)
-	assert.NoError(t, err)
-
-	metarepo := New(storeClient)
+	metarepo := NewTestMetarepo()
 	metarepo.DeleteMapping("/")
 	metarepo.DeleteData("/")
 
@@ -415,20 +351,7 @@ func TestWatch(t *testing.T) {
 }
 
 func TestWatchSelf(t *testing.T) {
-	prefix := fmt.Sprintf("/prefix%v", rand.Intn(1000))
-	group := fmt.Sprintf("/group%v", rand.Intn(1000))
-	nodes := backends.GetDefaultBackends(backend)
-
-	config := backends.Config{
-		Backend:      backend,
-		BackendNodes: nodes,
-		Prefix:       prefix,
-		Group:        group,
-	}
-	storeClient, err := backends.New(config)
-	assert.NoError(t, err)
-
-	metarepo := New(storeClient)
+	metarepo := NewTestMetarepo()
 	metarepo.DeleteMapping("/")
 	metarepo.DeleteData("/")
 
@@ -437,7 +360,7 @@ func TestWatchSelf(t *testing.T) {
 
 	ip := "192.168.1.1"
 
-	err = metarepo.PutMapping(ip, map[string]interface{}{
+	err := metarepo.PutMapping(ip, map[string]interface{}{
 		"node": "/nodes/1",
 	}, true)
 	assert.NoError(t, err)
@@ -499,26 +422,13 @@ func TestWatchSelf(t *testing.T) {
 }
 
 func TestWatchCloseChan(t *testing.T) {
-	prefix := fmt.Sprintf("/prefix%v", rand.Intn(1000))
-	group := fmt.Sprintf("/group%v", rand.Intn(1000))
-	nodes := backends.GetDefaultBackends(backend)
-
-	config := backends.Config{
-		Backend:      backend,
-		BackendNodes: nodes,
-		Prefix:       prefix,
-		Group:        group,
-	}
-	storeClient, err := backends.New(config)
-	assert.NoError(t, err)
-
-	metarepo := New(storeClient)
+	metarepo := NewTestMetarepo()
 
 	metarepo.StartSync()
 
 	ip := "192.168.1.1"
 
-	err = metarepo.PutMapping(ip, map[string]interface{}{
+	err := metarepo.PutMapping(ip, map[string]interface{}{
 		"node": "/nodes/1",
 	}, true)
 	assert.NoError(t, err)
@@ -555,20 +465,7 @@ func TestWatchCloseChan(t *testing.T) {
 // TestSelfWatchNodeNotExist
 // create a mapping with a node not exist, then update the node
 func TestSelfWatchNodeNotExist(t *testing.T) {
-	prefix := fmt.Sprintf("/prefix%v", rand.Intn(1000))
-	group := fmt.Sprintf("/group%v", rand.Intn(1000))
-	nodes := backends.GetDefaultBackends(backend)
-
-	config := backends.Config{
-		Backend:      backend,
-		BackendNodes: nodes,
-		Prefix:       prefix,
-		Group:        group,
-	}
-	storeClient, err := backends.New(config)
-	assert.NoError(t, err)
-
-	metarepo := New(storeClient)
+	metarepo := NewTestMetarepo()
 
 	metarepo.StartSync()
 
@@ -576,7 +473,7 @@ func TestSelfWatchNodeNotExist(t *testing.T) {
 
 	ip := "192.168.1.1"
 
-	err = metarepo.PutMapping(ip, map[string]interface{}{
+	err := metarepo.PutMapping(ip, map[string]interface{}{
 		"host": "/hosts/i-local",
 		"cmd":  "/cmd/i-local",
 	}, true)
@@ -604,6 +501,74 @@ func TestSelfWatchNodeNotExist(t *testing.T) {
 	assert.NotNil(t, result)
 	//closeChan <- true
 	metarepo.StopSync()
+}
+
+func TestAccessRule(t *testing.T) {
+	metarepo := NewTestMetarepo()
+	metarepo.StartSync()
+
+	data := map[string]interface{}{
+		"clusters": map[string]interface{}{
+			"cl-1": map[string]interface{}{
+				"name": "cl-1",
+				"env": map[string]interface{}{
+					"username": "user1",
+					"secret":   "123456",
+				},
+				"public_key": "public_key_val",
+			},
+			"cl-2": map[string]interface{}{
+				"name": "cl-2",
+				"env": map[string]interface{}{
+					"username": "user2",
+					"secret":   "1234567",
+				},
+				"public_key": "public_key_val2",
+			},
+		},
+	}
+
+	err := metarepo.PutData("/", data, true)
+	assert.NoError(t, err)
+
+	ip := "192.168.1.1"
+	rules := map[string][]store.AccessRule{
+		ip: {
+			{Path: "/", Mode: store.AccessModeRead},
+		},
+	}
+
+	err = metarepo.PutAccessRule(rules)
+	assert.NoError(t, err)
+
+	time.Sleep(sleepTime)
+
+	rulesGet := metarepo.GetAccessRule([]string{ip})
+	assert.Equal(t, rules, rulesGet)
+
+	_, dataGet := metarepo.Root(ip, "/")
+	assert.Equal(t, data, dataGet)
+
+	metarepo.StopSync()
+}
+
+func NewTestMetarepo() *MetadataRepo {
+	prefix := fmt.Sprintf("/prefix%v", rand.Intn(10000))
+	group := fmt.Sprintf("/group%v", rand.Intn(10000))
+	nodes := backends.GetDefaultBackends(backend)
+
+	config := backends.Config{
+		Backend:      backend,
+		BackendNodes: nodes,
+		Prefix:       prefix,
+		Group:        group,
+	}
+	storeClient, err := backends.New(config)
+	if err != nil {
+		panic(err)
+	}
+
+	return New(storeClient)
 }
 
 func FillTestData(metarepo *MetadataRepo) map[string]string {

--- a/metadata/metarepo_test.go
+++ b/metadata/metarepo_test.go
@@ -38,7 +38,7 @@ func TestMetarepoData(t *testing.T) {
 	storeClient, err := backends.New(config)
 	assert.NoError(t, err)
 
-	metarepo := New(false, storeClient)
+	metarepo := New(storeClient)
 	metarepo.DeleteData("/")
 
 	metarepo.StartSync()
@@ -46,8 +46,14 @@ func TestMetarepoData(t *testing.T) {
 	testData := FillTestData(metarepo)
 	time.Sleep(sleepTime)
 	ValidTestData(t, testData, metarepo.data)
-
-	_, val := metarepo.Root("192.168.0.1", "/nodes/0")
+	clientIP := "192.168.0.1"
+	accessRule := map[string][]store.AccessRule{
+		clientIP: {
+			{Path: "/", Mode: store.AccessModeRead},
+		},
+	}
+	metarepo.PutAccessRule(accessRule)
+	_, val := metarepo.Root(clientIP, "/nodes/0")
 	assert.NotNil(t, val)
 
 	mapVal, mok := val.(map[string]interface{})
@@ -95,7 +101,7 @@ func TestMetarepoMapping(t *testing.T) {
 	storeClient, err := backends.New(config)
 	assert.NoError(t, err)
 
-	metarepo := New(false, storeClient)
+	metarepo := New(storeClient)
 	metarepo.DeleteData("/")
 	metarepo.DeleteMapping("/")
 
@@ -203,7 +209,7 @@ func TestMetarepoSelf(t *testing.T) {
 	storeClient, err := backends.New(config)
 	assert.NoError(t, err)
 
-	metarepo := New(false, storeClient)
+	metarepo := New(storeClient)
 
 	metarepo.DeleteMapping("/")
 	metarepo.DeleteData("/")
@@ -294,7 +300,7 @@ func TestMetarepoRoot(t *testing.T) {
 	storeClient, err := backends.New(config)
 	assert.NoError(t, err)
 
-	metarepo := New(false, storeClient)
+	metarepo := New(storeClient)
 
 	metarepo.DeleteMapping("/")
 	metarepo.DeleteData("/")
@@ -305,6 +311,14 @@ func TestMetarepoRoot(t *testing.T) {
 	time.Sleep(sleepTime)
 
 	ip := "192.168.1.0"
+
+	accessRule := map[string][]store.AccessRule{
+		ip: {
+			{Path: "/", Mode: store.AccessModeRead},
+		},
+	}
+	metarepo.PutAccessRule(accessRule)
+
 	mapping := make(map[string]interface{})
 	mapping["node"] = "/nodes/0"
 	err = metarepo.PutMapping(ip, mapping, true)
@@ -319,14 +333,6 @@ func TestMetarepoRoot(t *testing.T) {
 	selfVal := mapVal["self"]
 	assert.NotNil(t, selfVal)
 	assert.True(t, len(mapVal) > 1)
-
-	metarepo.SetOnlySelf(true)
-
-	_, val = metarepo.Root(ip, "/")
-	mapVal = val.(map[string]interface{})
-	selfVal = mapVal["self"]
-	assert.NotNil(t, selfVal)
-	assert.True(t, len(mapVal) == 1)
 
 	metarepo.DeleteData("/")
 	metarepo.DeleteMapping("/")
@@ -347,7 +353,7 @@ func TestWatch(t *testing.T) {
 	storeClient, err := backends.New(config)
 	assert.NoError(t, err)
 
-	metarepo := New(false, storeClient)
+	metarepo := New(storeClient)
 	metarepo.DeleteMapping("/")
 	metarepo.DeleteData("/")
 
@@ -420,7 +426,7 @@ func TestWatchSelf(t *testing.T) {
 	storeClient, err := backends.New(config)
 	assert.NoError(t, err)
 
-	metarepo := New(false, storeClient)
+	metarepo := New(storeClient)
 	metarepo.DeleteMapping("/")
 	metarepo.DeleteData("/")
 
@@ -504,7 +510,7 @@ func TestWatchCloseChan(t *testing.T) {
 	storeClient, err := backends.New(config)
 	assert.NoError(t, err)
 
-	metarepo := New(false, storeClient)
+	metarepo := New(storeClient)
 
 	metarepo.StartSync()
 
@@ -560,7 +566,7 @@ func TestSelfWatchNodeNotExist(t *testing.T) {
 	storeClient, err := backends.New(config)
 	assert.NoError(t, err)
 
-	metarepo := New(false, storeClient)
+	metarepo := New(storeClient)
 
 	metarepo.StartSync()
 

--- a/store/access.go
+++ b/store/access.go
@@ -2,20 +2,55 @@ package store
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
+	"sync"
 )
 
 type AccessMode int
 
 const (
+	begin               = AccessMode(-2)
 	AccessModeNil       = AccessMode(-1)
 	AccessModeForbidden = AccessMode(0)
 	AccessModeRead      = AccessMode(1)
+	end                 = AccessMode(2)
 )
+
+func CheckAccessMode(mode AccessMode) bool {
+	if mode <= begin || mode >= end {
+		return false
+	}
+	return true
+}
+
+func CheckAccessRules(rules []AccessRule) error {
+	keys := make(map[string]*struct{}, len(rules))
+	for _, r := range rules {
+		if !CheckAccessMode(r.Mode) {
+			return fmt.Errorf("Invalid AccessMode [%v]", r.Mode)
+		}
+		if _, ok := keys[r.Path]; ok {
+			return fmt.Errorf("AccessRule path [%s] repeat define.", r.Path)
+		}
+	}
+	return nil
+}
 
 type AccessRule struct {
 	Path string     `json:"path"`
 	Mode AccessMode `json:"mode"`
+}
+
+func MarshalAccessRule(rules []AccessRule) string {
+	b, _ := json.Marshal(rules)
+	return string(b)
+}
+
+func UnmarshalAccessRule(data string) ([]AccessRule, error) {
+	rules := []AccessRule{}
+	err := json.Unmarshal([]byte(data), &rules)
+	return rules, err
 }
 
 type AccessNode struct {
@@ -25,11 +60,11 @@ type AccessNode struct {
 	Children []*AccessNode
 }
 
-func (n *AccessNode) HasChildren() bool {
+func (n *AccessNode) HasChild() bool {
 	return len(n.Children) > 0
 }
 
-func (n *AccessNode) GetChildren(name string, strict bool) *AccessNode {
+func (n *AccessNode) GetChild(name string, strict bool) *AccessNode {
 	var wildcardNode *AccessNode
 	for _, c := range n.Children {
 		if name == c.Name {
@@ -42,22 +77,98 @@ func (n *AccessNode) GetChildren(name string, strict bool) *AccessNode {
 	return wildcardNode
 }
 
-type AccessTree struct {
+type AccessStore interface {
+	Get(host string) AccessTree
+	GetAccessRule(hosts []string) map[string][]AccessRule
+	Put(host string, rules []AccessRule)
+	Puts(rules map[string][]AccessRule)
+	Delete(host string)
+}
+
+func NewAccessStore() AccessStore {
+	return &accessStore{m: make(map[string]AccessTree)}
+}
+
+type accessStore struct {
+	m    map[string]AccessTree
+	lock sync.RWMutex
+}
+
+func (s *accessStore) Delete(host string) {
+	s.lock.Lock()
+	delete(s.m, host)
+	s.lock.Unlock()
+}
+
+func (s *accessStore) Get(host string) AccessTree {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.m[host]
+}
+
+func (s *accessStore) Put(host string, rules []AccessRule) {
+	s.lock.Lock()
+	s.m[host] = NewAccessTree(rules)
+	s.lock.Unlock()
+}
+
+func (s *accessStore) Puts(rules map[string][]AccessRule) {
+	s.lock.Lock()
+	for k, v := range rules {
+		s.m[k] = NewAccessTree(v)
+	}
+	s.lock.Unlock()
+}
+
+func (s *accessStore) GetAccessRule(hosts []string) map[string][]AccessRule {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	result := map[string][]AccessRule{}
+	if len(hosts) == 0 {
+		for k, v := range s.m {
+			result[k] = v.ToAccessRule()
+		}
+	} else {
+		for _, host := range hosts {
+			t, ok := s.m[host]
+			if ok {
+				result[host] = t.ToAccessRule()
+			}
+		}
+	}
+	return result
+}
+
+type AccessTree interface {
+	GetRoot() *AccessNode
+	ToAccessRule() []AccessRule
+	Json() string
+}
+
+type accessTree struct {
 	Root *AccessNode
 }
 
-func (t *AccessTree) Json() string {
+func (t *accessTree) GetRoot() *AccessNode {
+	return t.Root
+}
+
+func (t *accessTree) ToAccessRule() []AccessRule {
+	return nil
+}
+
+func (t *accessTree) Json() string {
 	b, _ := json.MarshalIndent(t.Root, "", "  ")
 	return string(b)
 }
 
-func NewAccessTree(rules []AccessRule) *AccessTree {
+func NewAccessTree(rules []AccessRule) AccessTree {
 	root := &AccessNode{
 		Name:   "/",
 		Mode:   AccessModeNil,
 		parent: nil,
 	}
-	tree := &AccessTree{
+	tree := &accessTree{
 		Root: root,
 	}
 	for _, rule := range rules {
@@ -69,7 +180,7 @@ func NewAccessTree(rules []AccessRule) *AccessTree {
 				if component == "" {
 					continue
 				}
-				child := curr.GetChildren(component, true)
+				child := curr.GetChild(component, true)
 				if child == nil {
 					child = &AccessNode{Name: component, Mode: AccessModeNil, parent: curr}
 					curr.Children = append(curr.Children, child)

--- a/store/access.go
+++ b/store/access.go
@@ -1,0 +1,83 @@
+package store
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+type AccessMode int
+
+const (
+	AccessModeNil       = AccessMode(-1)
+	AccessModeForbidden = AccessMode(0)
+	AccessModeRead      = AccessMode(1)
+)
+
+type AccessRule struct {
+	Path string     `json:"path"`
+	Mode AccessMode `json:"mode"`
+}
+
+type AccessNode struct {
+	Name     string
+	Mode     AccessMode
+	parent   *AccessNode
+	Children []*AccessNode
+}
+
+func (n *AccessNode) HasChildren() bool {
+	return len(n.Children) > 0
+}
+
+func (n *AccessNode) GetChildren(name string, strict bool) *AccessNode {
+	var wildcardNode *AccessNode
+	for _, c := range n.Children {
+		if name == c.Name {
+			return c
+		}
+		if !strict && c.Name == "*" {
+			wildcardNode = c
+		}
+	}
+	return wildcardNode
+}
+
+type AccessTree struct {
+	Root *AccessNode
+}
+
+func (t *AccessTree) Json() string {
+	b, _ := json.MarshalIndent(t.Root, "", "  ")
+	return string(b)
+}
+
+func NewAccessTree(rules []AccessRule) *AccessTree {
+	root := &AccessNode{
+		Name:   "/",
+		Mode:   AccessModeNil,
+		parent: nil,
+	}
+	tree := &AccessTree{
+		Root: root,
+	}
+	for _, rule := range rules {
+		p := rule.Path
+		curr := root
+		if p != "/" {
+			components := strings.Split(p, "/")
+			for _, component := range components {
+				if component == "" {
+					continue
+				}
+				child := curr.GetChildren(component, true)
+				if child == nil {
+					child = &AccessNode{Name: component, Mode: AccessModeNil, parent: curr}
+					curr.Children = append(curr.Children, child)
+				}
+				curr = child
+			}
+		}
+		curr.Mode = rule.Mode
+	}
+	return tree
+}

--- a/store/access.go
+++ b/store/access.go
@@ -139,6 +139,9 @@ func (s *accessStore) GetAccessRule(hosts []string) map[string][]AccessRule {
 		}
 	} else {
 		for _, host := range hosts {
+			if host == "" {
+				continue
+			}
 			t, ok := s.m[host]
 			if ok {
 				result[host] = t.ToAccessRule()

--- a/store/access_test.go
+++ b/store/access_test.go
@@ -27,7 +27,7 @@ func TestAccessStore(t *testing.T) {
 	rules1 := rulesGet[ip]
 	assert.Equal(t, rules, rules1)
 
-	rulesGet2 := accessStore.GetAccessRule([]string{})
+	rulesGet2 := accessStore.GetAccessRule(nil)
 	assert.Equal(t, rules, rulesGet2[ip])
 	assert.Equal(t, rules, rulesGet2[ip2])
 

--- a/store/access_test.go
+++ b/store/access_test.go
@@ -1,0 +1,58 @@
+package store
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestAccessStore(t *testing.T) {
+	accessStore := NewAccessStore()
+	ip := "192.168.1.1"
+	rules := []AccessRule{
+		{Path: "/", Mode: AccessModeForbidden},
+		{Path: "/clusters", Mode: AccessModeRead},
+		{Path: "/clusters/cl-1/env/secret", Mode: AccessModeForbidden},
+	}
+	accessStore.Put(ip, rules)
+
+	tree := accessStore.Get(ip)
+	assert.NotNil(t, tree)
+
+	ip2 := "192.168.1.2"
+	accessStore.Puts(map[string][]AccessRule{
+		ip2: rules,
+	})
+	rulesGet := accessStore.GetAccessRule([]string{ip})
+	rules1 := rulesGet[ip]
+	assert.Equal(t, rules, rules1)
+
+	rulesGet2 := accessStore.GetAccessRule([]string{})
+	assert.Equal(t, rules, rulesGet2[ip])
+	assert.Equal(t, rules, rulesGet2[ip2])
+
+	accessStore.Delete(ip)
+	rulesGet3 := accessStore.GetAccessRule([]string{})
+	assert.Equal(t, 1, len(rulesGet3))
+}
+
+func TestAccessTree(t *testing.T) {
+	rules := []AccessRule{
+		{Path: "/", Mode: AccessModeForbidden},
+		{Path: "/clusters", Mode: AccessModeRead},
+		{Path: "/clusters/*/env", Mode: AccessModeForbidden},
+		{Path: "/clusters/cl-1/env/secret", Mode: AccessModeRead},
+	}
+	tree := NewAccessTree(rules)
+	jsonStr := tree.Json()
+	jsonMap := map[string]interface{}{}
+	err := json.Unmarshal([]byte(jsonStr), &jsonMap)
+	assert.NoError(t, err)
+	root := tree.GetRoot()
+	assert.Equal(t, AccessModeForbidden, root.Mode)
+	assert.Equal(t, AccessModeRead, root.GetChild("clusters", true).Mode)
+	assert.Equal(t, AccessModeForbidden, root.GetChild("clusters", true).
+		GetChild("cl-2", false).GetChild("env", true).Mode)
+	assert.Equal(t, AccessModeRead, root.GetChild("clusters", true).
+		GetChild("cl-1", false).GetChild("env", true).GetChild("secret", true).Mode)
+}

--- a/store/node.go
+++ b/store/node.go
@@ -78,15 +78,6 @@ func (n *node) IsRoot() bool {
 	return n.parent == nil
 }
 
-// IsHidden function checks if the node is a hidden node. A hidden node
-// will begin with '_'
-// A hidden node will not be shown via get command under a directory
-// For example if we have /foo/_hidden and /foo/notHidden, get "/foo"
-// will only return /foo/notHidden
-func (n *node) IsHidden() bool {
-	return n.Name[0] == '_'
-}
-
 // IsDir function checks whether the node is a dir.
 func (n *node) IsDir() bool {
 	return n.Children != nil
@@ -243,10 +234,6 @@ func (n *node) GetValue() interface{} {
 	if n.IsDir() {
 		values := make(map[string]interface{})
 		for k, node := range n.Children {
-			//skip hidden node.
-			if node.IsHidden() {
-				continue
-			}
 			v := node.GetValue()
 			m, isMap := v.(map[string]interface{})
 			// skip empty dir.

--- a/store/store.go
+++ b/store/store.go
@@ -32,6 +32,8 @@ type Store interface {
 	Version() int64
 	// Destroy the store
 	Destroy()
+	// Traveller
+	Traveller(rules []AccessRule) Traveller
 }
 
 type store struct {
@@ -179,6 +181,10 @@ func (s *store) Destroy() {
 	s.Root = nil
 }
 
+func (s *store) Traveller(rules []AccessRule) Traveller {
+	return newNodeTraveller(s, rules)
+}
+
 // walk walks all the nodePath and apply the walkFunc on each directory
 func (s *store) walk(nodePath string, walkFunc func(prev *node, component string) *node) *node {
 	components := strings.Split(nodePath, "/")
@@ -188,9 +194,8 @@ func (s *store) walk(nodePath string, walkFunc func(prev *node, component string
 	for i := 1; i < len(components); i++ {
 		if len(components[i]) == 0 {
 			// ignore empty string
-			return curr
+			continue
 		}
-
 		curr = walkFunc(curr, components[i])
 		if curr == nil {
 			return nil

--- a/store/store.go
+++ b/store/store.go
@@ -33,7 +33,7 @@ type Store interface {
 	// Destroy the store
 	Destroy()
 	// Traveller
-	Traveller(rules []AccessRule) Traveller
+	Traveller(accessTree *AccessTree) Traveller
 }
 
 type store struct {
@@ -181,8 +181,8 @@ func (s *store) Destroy() {
 	s.Root = nil
 }
 
-func (s *store) Traveller(rules []AccessRule) Traveller {
-	return newTraveller(s, rules)
+func (s *store) Traveller(accessTree *AccessTree) Traveller {
+	return newTraveller(s, accessTree)
 }
 
 // walk walks all the nodePath and apply the walkFunc on each directory

--- a/store/store.go
+++ b/store/store.go
@@ -182,7 +182,7 @@ func (s *store) Destroy() {
 }
 
 func (s *store) Traveller(rules []AccessRule) Traveller {
-	return newNodeTraveller(s, rules)
+	return newTraveller(s, rules)
 }
 
 // walk walks all the nodePath and apply the walkFunc on each directory

--- a/store/store.go
+++ b/store/store.go
@@ -33,7 +33,7 @@ type Store interface {
 	// Destroy the store
 	Destroy()
 	// Traveller
-	Traveller(accessTree *AccessTree) Traveller
+	Traveller(accessTree AccessTree) Traveller
 }
 
 type store struct {
@@ -181,7 +181,7 @@ func (s *store) Destroy() {
 	s.Root = nil
 }
 
-func (s *store) Traveller(accessTree *AccessTree) Traveller {
+func (s *store) Traveller(accessTree AccessTree) Traveller {
 	return newTraveller(s, accessTree)
 }
 

--- a/store/traveller.go
+++ b/store/traveller.go
@@ -50,16 +50,17 @@ func (s *travellerStack) Clean() {
 
 type nodeTraveller struct {
 	store          *store
-	access         *AccessTree
+	access         AccessTree
 	currNode       *node
 	currAccessNode *AccessNode
 	currMode       AccessMode
 	stack          travellerStack
 }
 
-func newTraveller(store *store, accessTree *AccessTree) Traveller {
+func newTraveller(store *store, accessTree AccessTree) Traveller {
 	store.worldLock.RLock()
-	return &nodeTraveller{store: store, access: accessTree, currNode: store.Root, currAccessNode: accessTree.Root, currMode: accessTree.Root.Mode}
+	currAccessNode := accessTree.GetRoot()
+	return &nodeTraveller{store: store, access: accessTree, currNode: store.Root, currAccessNode: currAccessNode, currMode: currAccessNode.Mode}
 }
 
 func (t *nodeTraveller) Enter(path string) bool {
@@ -95,12 +96,12 @@ func (t *nodeTraveller) enter(node string) bool {
 	}
 	var an *AccessNode
 	if t.currAccessNode != nil {
-		an = t.currAccessNode.GetChildren(node, false)
+		an = t.currAccessNode.GetChild(node, false)
 	}
 	result := false
 	if an != nil {
-		// if an HasChildren, means exist other rule for future access
-		if an.HasChildren() || an.Mode >= AccessModeRead {
+		// if an HasChild, means exist other rule for future access
+		if an.HasChild() || an.Mode >= AccessModeRead {
 			result = true
 		}
 	} else {
@@ -149,7 +150,7 @@ func (t *nodeTraveller) BackToRoot() {
 	}
 	t.stack.Clean()
 	t.currNode = t.store.Root
-	t.currAccessNode = t.access.Root
+	t.currAccessNode = t.access.GetRoot()
 	t.currMode = t.currAccessNode.Mode
 }
 

--- a/store/traveller.go
+++ b/store/traveller.go
@@ -1,0 +1,219 @@
+package store
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+type AccessMode int
+type EnterResult int
+
+const (
+	AccessModeNil       = AccessMode(-1)
+	AccessModeForbidden = AccessMode(0)
+	AccessModeRead      = AccessMode(1)
+)
+
+type AccessRule struct {
+	Path string
+	Mode AccessMode
+}
+
+type Traveller interface {
+	// can Enter node
+	Enter(node string) bool
+	// Back to parent dir
+	Back()
+
+	GetValue() interface{}
+}
+
+type pathTree struct {
+	root *pathNode
+}
+
+func (t *pathTree) Json() string {
+	b, _ := json.MarshalIndent(t.root, "", "  ")
+	return string(b)
+}
+
+type pathNode struct {
+	Name     string
+	Mode     AccessMode
+	parent   *pathNode
+	Children []*pathNode
+}
+
+func (n *pathNode) HasChildren() bool {
+	return len(n.Children) > 0
+}
+
+func (n *pathNode) GetChildren(name string, strict bool) *pathNode {
+	var wildcardNode *pathNode
+	for _, c := range n.Children {
+		if name == c.Name {
+			return c
+		}
+		if !strict && c.Name == "*" {
+			wildcardNode = c
+		}
+	}
+	return wildcardNode
+}
+
+func newNodeTraveller(store *store, rules []AccessRule) Traveller {
+	return &nodeTraveller{store: store, tree: buildPathTree(rules)}
+}
+
+func buildPathTree(rules []AccessRule) *pathTree {
+	root := &pathNode{
+		Name:   "/",
+		Mode:   AccessModeNil,
+		parent: nil,
+	}
+	tree := &pathTree{
+		root: root,
+	}
+	for _, rule := range rules {
+		p := rule.Path
+		curr := root
+		if p != "/" {
+			components := strings.Split(p, "/")
+			for _, component := range components {
+				if component == "" {
+					continue
+				}
+				child := curr.GetChildren(component, true)
+				if child == nil {
+					child = &pathNode{Name: component, Mode: AccessModeNil, parent: curr}
+					curr.Children = append(curr.Children, child)
+				}
+				curr = child
+			}
+		}
+		curr.Mode = rule.Mode
+	}
+	return tree
+}
+
+type stackElement struct {
+	pathNode *pathNode
+	mode     AccessMode
+}
+
+type travellerStack struct {
+	backend []interface{}
+}
+
+func (s *travellerStack) Push(v interface{}) {
+	s.backend = append(s.backend, v)
+}
+
+func (s *travellerStack) Pop() interface{} {
+	l := len(s.backend)
+	if l == 0 {
+		return nil
+	}
+	e := s.backend[l-1]
+	s.backend = s.backend[:l-1]
+	return e
+}
+
+type nodeTraveller struct {
+	store        *store
+	tree         *pathTree
+	currNode     *node
+	currPathNode *pathNode
+	currMode     AccessMode
+	stack        travellerStack
+}
+
+func (t *nodeTraveller) Enter(dir string) bool {
+	if dir == "/" {
+		if t.currNode == nil {
+			t.stack.Push(&stackElement{pathNode: t.currPathNode, mode: t.currMode})
+			t.currNode = t.store.Root
+			t.currPathNode = t.tree.root
+			t.currMode = t.currPathNode.Mode
+			return true
+		}
+		return false
+	}
+	if t.currNode == nil {
+		return false
+	}
+	n := t.currNode.GetChild(dir)
+	if n == nil {
+		return false
+	}
+	//if !n.IsDir() {
+	//	return EnterNotDir
+	//}
+
+	var p *pathNode
+	if t.currPathNode != nil {
+		p = t.currPathNode.GetChildren(dir, false)
+	}
+	result := false
+	if p != nil {
+		// if p HasChildren, means exist other rule for future access
+		if p.HasChildren() || p.Mode >= AccessModeRead {
+			result = true
+		}
+	} else {
+		if t.currMode >= AccessModeRead {
+			result = true
+		}
+	}
+
+	if result {
+		t.stack.Push(&stackElement{pathNode: t.currPathNode, mode: t.currMode})
+		t.currNode = n
+		t.currPathNode = p
+		if t.currPathNode != nil && t.currPathNode.Mode != AccessModeNil {
+			t.currMode = t.currPathNode.Mode
+		}
+
+	}
+	return result
+}
+
+func (t *nodeTraveller) Back() {
+	if t.currNode == nil || t.currNode.IsRoot() {
+		panic("illegal status")
+	}
+	e := t.stack.Pop()
+	if e == nil {
+		panic("illegal status")
+	}
+	ele := e.(*stackElement)
+	t.currNode = t.currNode.parent
+	t.currMode = ele.mode
+	t.currPathNode = ele.pathNode
+}
+
+func (t *nodeTraveller) GetValue() interface{} {
+	if t.currNode == nil {
+		panic("illegal status.")
+	}
+	if t.currNode.IsDir() {
+		values := make(map[string]interface{})
+		for k, node := range t.currNode.Children {
+			eresult := t.Enter(node.Name)
+			if !eresult {
+				continue
+			}
+			v := t.GetValue()
+			t.Back()
+			m, isMap := v.(map[string]interface{})
+			// skip empty dir.
+			if isMap && len(m) == 0 {
+				continue
+			}
+			values[k] = v
+		}
+		return values
+	} else {
+		return t.currNode.Value
+	}
+}

--- a/store/traveller.go
+++ b/store/traveller.go
@@ -22,7 +22,7 @@ type Traveller interface {
 }
 
 type stackElement struct {
-	node *AccessNode
+	node *accessNode
 	mode AccessMode
 }
 
@@ -52,7 +52,7 @@ type nodeTraveller struct {
 	store          *store
 	access         AccessTree
 	currNode       *node
-	currAccessNode *AccessNode
+	currAccessNode *accessNode
 	currMode       AccessMode
 	stack          travellerStack
 }
@@ -94,7 +94,7 @@ func (t *nodeTraveller) enter(node string) bool {
 	if n == nil {
 		return false
 	}
-	var an *AccessNode
+	var an *accessNode
 	if t.currAccessNode != nil {
 		an = t.currAccessNode.GetChild(node, false)
 	}

--- a/store/traveller_test.go
+++ b/store/traveller_test.go
@@ -1,0 +1,87 @@
+package store
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	//"encoding/json"
+)
+
+func TestNodeTraveller(t *testing.T) {
+	s := New()
+	data := map[string]interface{}{
+		"clusters": map[string]interface{}{
+			"cl-1": map[string]interface{}{
+				"env": map[string]interface{}{
+					"name":   "app1",
+					"secret": "123456",
+				},
+				"public_key": "public_key_val",
+			},
+			"cl-2": map[string]interface{}{
+				"env": map[string]interface{}{
+					"name":   "app2",
+					"secret": "1234567",
+				},
+				"public_key": "public_key_val2",
+			},
+		},
+	}
+	s.Put("/", data)
+
+	accessRules := []AccessRule{
+		{
+			Path: "/",
+			Mode: AccessModeForbidden,
+		},
+		{
+			Path: "/clusters",
+			Mode: AccessModeRead,
+		},
+		{
+			Path: "/clusters/*/env",
+			Mode: AccessModeForbidden,
+		},
+		{
+			Path: "/clusters/cl-1",
+			Mode: AccessModeRead,
+		},
+	}
+	traveller := s.Traveller(accessRules)
+	nodeTraveller := traveller.(*nodeTraveller)
+	fmt.Println(nodeTraveller.tree.Json())
+
+	assert.True(t, traveller.Enter("/"))
+	assert.True(t, traveller.Enter("clusters"))
+	assert.True(t, traveller.Enter("cl-1"))
+	assert.True(t, traveller.Enter("env"))
+	//assert.True(t, EnterForbidden, traveller.Enter("env"))
+
+	traveller = s.Traveller(accessRules)
+	assert.True(t, traveller.Enter("/"))
+	assert.True(t, traveller.Enter("clusters"))
+	assert.True(t, traveller.Enter("cl-2"))
+	assert.False(t, traveller.Enter("env"))
+
+	traveller = s.Traveller(accessRules)
+	assert.True(t, traveller.Enter("/"))
+	assert.True(t, traveller.Enter("clusters"))
+	assert.True(t, traveller.Enter("cl-2"))
+	assert.True(t, traveller.Enter("public_key"))
+
+	traveller = s.Traveller(accessRules)
+	traveller.Enter("/")
+	traveller.Enter("clusters")
+	//traveller.Enter("cl-2")
+	v := traveller.GetValue()
+	//j,_ := json.MarshalIndent(v, "", "  ")
+	//fmt.Printf("%s", string(j))
+	mVal, ok := v.(map[string]interface{})
+	assert.True(t, ok)
+	cl1 := mVal["cl-1"].(map[string]interface{})
+	cl2 := mVal["cl-2"].(map[string]interface{})
+
+	envM := cl1["env"].(map[string]interface{})
+	assert.Equal(t, 2, len(envM))
+	assert.Nil(t, cl2["env"])
+}

--- a/store/traveller_test.go
+++ b/store/traveller_test.go
@@ -55,7 +55,7 @@ func TestTravellerEnter(t *testing.T) {
 		},
 	}
 
-	traveller := s.Traveller(accessRules)
+	traveller := s.Traveller(NewAccessTree(accessRules))
 	defer traveller.Close()
 	assert.True(t, traveller.Enter("/clusters"))
 	assert.True(t, traveller.Enter("/cl-1/env"))
@@ -113,7 +113,7 @@ func TestTraveller(t *testing.T) {
 			Mode: AccessModeRead,
 		},
 	}
-	traveller := s.Traveller(accessRules)
+	traveller := s.Traveller(NewAccessTree(accessRules))
 	defer traveller.Close()
 
 	nodeTraveller := traveller.(*nodeTraveller)

--- a/store/traveller_test.go
+++ b/store/traveller_test.go
@@ -7,7 +7,71 @@ import (
 	//"encoding/json"
 )
 
-func TestNodeTraveller(t *testing.T) {
+func TestTravellerStack(t *testing.T) {
+	stack := &travellerStack{}
+
+	assert.Nil(t, stack.Pop())
+
+	one := &stackElement{node: nil, mode: AccessModeNil}
+	two := &stackElement{node: nil, mode: AccessModeForbidden}
+	three := &stackElement{node: nil, mode: AccessModeRead}
+	stack.Push(one)
+	stack.Push(two)
+	stack.Push(three)
+
+	assert.Equal(t, three, stack.Pop())
+	assert.Equal(t, two, stack.Pop())
+	assert.Equal(t, one, stack.Pop())
+
+	assert.Nil(t, stack.Pop())
+}
+
+func TestTravellerEnter(t *testing.T) {
+	s := New()
+	data := map[string]interface{}{
+		"clusters": map[string]interface{}{
+			"cl-1": map[string]interface{}{
+				"env": map[string]interface{}{
+					"name":   "app1",
+					"secret": "123456",
+				},
+				"public_key": "public_key_val",
+			},
+			"cl-2": map[string]interface{}{
+				"env": map[string]interface{}{
+					"name":   "app2",
+					"secret": "1234567",
+				},
+				"public_key": "public_key_val2",
+			},
+		},
+	}
+	s.Put("/", data)
+
+	accessRules := []AccessRule{
+		{
+			Path: "/",
+			Mode: AccessModeRead,
+		},
+	}
+
+	traveller := s.Traveller(accessRules)
+	assert.True(t, traveller.Enter("/clusters"))
+	assert.True(t, traveller.Enter("/cl-1/env"))
+	assert.True(t, traveller.Enter("name"))
+	assert.Equal(t, "app1", traveller.GetValue())
+
+	traveller.BackToRoot()
+	assert.True(t, traveller.Enter("/clusters/cl-1/env/secret"))
+	traveller.BackStep(2)
+	assert.True(t, traveller.Enter("public_key"))
+	assert.Equal(t, "public_key_val", traveller.GetValue())
+
+	traveller.BackToRoot()
+	assert.True(t, traveller.Enter("/"))
+}
+
+func TestTraveller(t *testing.T) {
 	s := New()
 	data := map[string]interface{}{
 		"clusters": map[string]interface{}{
@@ -49,29 +113,17 @@ func TestNodeTraveller(t *testing.T) {
 	}
 	traveller := s.Traveller(accessRules)
 	nodeTraveller := traveller.(*nodeTraveller)
-	fmt.Println(nodeTraveller.tree.Json())
+	fmt.Println(nodeTraveller.access.Json())
 
-	assert.True(t, traveller.Enter("/"))
-	assert.True(t, traveller.Enter("clusters"))
-	assert.True(t, traveller.Enter("cl-1"))
-	assert.True(t, traveller.Enter("env"))
-	//assert.True(t, EnterForbidden, traveller.Enter("env"))
+	assert.True(t, traveller.Enter("/clusters/cl-1/env"))
+	traveller.BackToRoot()
 
-	traveller = s.Traveller(accessRules)
-	assert.True(t, traveller.Enter("/"))
-	assert.True(t, traveller.Enter("clusters"))
-	assert.True(t, traveller.Enter("cl-2"))
-	assert.False(t, traveller.Enter("env"))
+	assert.False(t, traveller.Enter("/clusters/cl-2/env"))
+	assert.True(t, traveller.Enter("/clusters/cl-2/public_key"))
 
-	traveller = s.Traveller(accessRules)
-	assert.True(t, traveller.Enter("/"))
-	assert.True(t, traveller.Enter("clusters"))
-	assert.True(t, traveller.Enter("cl-2"))
-	assert.True(t, traveller.Enter("public_key"))
+	traveller.BackToRoot()
 
-	traveller = s.Traveller(accessRules)
-	traveller.Enter("/")
-	traveller.Enter("clusters")
+	traveller.Enter("/clusters")
 	//traveller.Enter("cl-2")
 	v := traveller.GetValue()
 	//j,_ := json.MarshalIndent(v, "", "  ")

--- a/store/traveller_test.go
+++ b/store/traveller_test.go
@@ -56,6 +56,7 @@ func TestTravellerEnter(t *testing.T) {
 	}
 
 	traveller := s.Traveller(accessRules)
+	defer traveller.Close()
 	assert.True(t, traveller.Enter("/clusters"))
 	assert.True(t, traveller.Enter("/cl-1/env"))
 	assert.True(t, traveller.Enter("name"))
@@ -69,6 +70,7 @@ func TestTravellerEnter(t *testing.T) {
 
 	traveller.BackToRoot()
 	assert.True(t, traveller.Enter("/"))
+
 }
 
 func TestTraveller(t *testing.T) {
@@ -112,6 +114,8 @@ func TestTraveller(t *testing.T) {
 		},
 	}
 	traveller := s.Traveller(accessRules)
+	defer traveller.Close()
+
 	nodeTraveller := traveller.(*nodeTraveller)
 	fmt.Println(nodeTraveller.access.Json())
 

--- a/util/helper.go
+++ b/util/helper.go
@@ -3,6 +3,7 @@ package util
 import (
 	"github.com/yunify/metad/util/flatmap"
 	"path"
+	"strconv"
 	"strings"
 )
 
@@ -46,4 +47,15 @@ func GetMapValue(m interface{}, nodePath string) string {
 	fm := flatmap.Flatten(m)
 	v := fm[nodePath]
 	return v
+}
+
+func ParseInt(value string, defaultValue int) int {
+	if value == "" {
+		return defaultValue
+	}
+	result, err := strconv.Atoi(value)
+	if err != nil {
+		result = defaultValue
+	}
+	return result
 }

--- a/vendor/github.com/Sirupsen/logrus/entry.go
+++ b/vendor/github.com/Sirupsen/logrus/entry.go
@@ -32,8 +32,8 @@ func NewEntry(logger *Logger) *Entry {
 	return &Entry{
 		Logger: logger,
 		// Default is three fields, give a little extra room
-		Data: 	make(Fields, 5),
-		Level:	logger.Level,
+		Data:  make(Fields, 5),
+		Level: logger.Level,
 	}
 }
 

--- a/vendor/github.com/Sirupsen/logrus/entry_test.go
+++ b/vendor/github.com/Sirupsen/logrus/entry_test.go
@@ -53,15 +53,15 @@ func TestEntryPanicf(t *testing.T) {
 }
 
 func TestEntryLogLevel(t *testing.T) {
-  	out := &bytes.Buffer{}
-  	logger := New()
-  	logger.Out = out
-  	logger.Level = DebugLevel
-  	entry := NewEntry(logger)
-  	assert.Equal(t, DebugLevel, entry.Level)
-  	entry.Level = WarnLevel
-  	entry.Info("it should not be displayed")
-  	assert.Equal(t, "", out.String())
-  	entry.Warn("it should be displayed")
-  	assert.Contains(t, out.String(), "it should be displayed")
+	out := &bytes.Buffer{}
+	logger := New()
+	logger.Out = out
+	logger.Level = DebugLevel
+	entry := NewEntry(logger)
+	assert.Equal(t, DebugLevel, entry.Level)
+	entry.Level = WarnLevel
+	entry.Info("it should not be displayed")
+	assert.Equal(t, "", out.String())
+	entry.Warn("it should be displayed")
+	assert.Contains(t, out.String(), "it should be displayed")
 }


### PR DESCRIPTION
通过独立定义访问规则的方式来限制节点获取 metadata 的范围。

### 新增接口：/v1/rule 用于提交访问规则。

1. PUT|POST:   修改，每个 ip 提交的访问规则会直接替换以前该 ip 的所有规则。

    ```json
    {
      "192.168.1.10":[{"path":"/clusters/cl-1", "mode":1}]
    }
    ```
2. GET:  获取
返回值同 POST，传递参数 hosts 表示要获取的访问规则的 ip，多个用逗号隔开，不传递表示获取全部。
3. DELETE: 删除 
传递参数 hosts 表示要删除的访问规则的 ip，多个用逗号隔开。

### 访问规则定义说明：

```go
type AccessRule struct {
	Path string     `json:"path"` //表示对该规则生效的路径
	Mode AccessMode `json:"mode"` //表示访问规则模式
}
```

访问规则模式说明：
*  0 表示禁止访问该路径
*  1 表示允许读取该路径

### 访问规则路径的特殊说明：

1. 访问路径中支持通配符 * 表示匹配所有
2. 明确路径规则的优先级高于通配符规则
3. 深路径规则的优先级高于浅路径

比如以下规则：

```json
[  
   {  
      "path":"/",
      "mode":0
   },
   {  
      "path":"/clusters",
      "mode":1
   },
   {  
      "path":"/clusters/*/env",
      "mode":0
   },
   {  
      "path":"/clusters/cl-1",
      "mode":1
   }
]
```

1. 根目录是禁止的，但 /cluster 是允许的，所以该客户端可以访问 /cluster 之下的目录，但访问根下的 cluster 之外的目录是不可以的。
2. /clusters/*/env 这个规则表示所有 clusters/cl-xxx 下的 env 目录是被禁止的，比如该客户端无法访问 /clusters/cl-2/env。
3. /clusters/cl-1 明确定义了 /clusters/cl-1 目录的读取权限，所以该客户端可以访问 /clusters/cl-1 下的所有数据，包括 /clusters/cl-1/env。
