### PR TITLE
Update log.go

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type LogFormatter struct {


### PR DESCRIPTION
```
go: github.com/yunify/metad/log imports
        github.com/Sirupsen/logrus: github.com/Sirupsen/logrus@v1.8.1: parsing go.mod:
        module declares its path as: github.com/sirupsen/logrus
                but was required as: github.com/Sirupsen/logrus

```