### PR TITLE
Fix gpc nameing

### DIFF
--- a/build
+++ b/build
@@ -11,6 +11,15 @@ gen_version
 
 echo "Building metad ..."
 mkdir -p bin
+
+go mod init
+
+# fix  google.golang.org/grpc/naming: module google.golang.org/grpc@latest found (v1.37.0), but does not contain package google.golang.org/grpc/naming
+# https://github.com/yunify/metad/issues/24
+go mod edit -replace google.golang.org/grpc@latest=google.golang.org/grpc@v1.26.0
+
+go mod tidy
+ 
 go build -o $OUTPUT .
 
 revert_version

--- a/build
+++ b/build
@@ -16,8 +16,9 @@ go mod init
 
 # fix  google.golang.org/grpc/naming: module google.golang.org/grpc@latest found (v1.37.0), but does not contain package google.golang.org/grpc/naming
 # https://github.com/yunify/metad/issues/24
-go mod edit -replace google.golang.org/grpc@latest=google.golang.org/grpc@v1.26.0
+go mod edit -replace google.golang.org/grpc@v1.37.0=google.golang.org/grpc@v1.3.0
 
+go mod vendor
 go mod tidy
  
 go build -o $OUTPUT .

--- a/log/log.go
+++ b/log/log.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type LogFormatter struct {


### PR DESCRIPTION
```
go: finding module for package google.golang.org/grpc/naming
github.com/yunify/metad/backends/etcdv3 imports
        github.com/coreos/etcd/clientv3 tested by
        github.com/coreos/etcd/clientv3.test imports
        github.com/coreos/etcd/integration imports
        github.com/coreos/etcd/proxy/grpcproxy imports
        google.golang.org/grpc/naming: module google.golang.org/grpc@latest found (v1.37.0), but does not contain package google.golang.org/grpc/naming

```